### PR TITLE
Document some conditional API property constraints

### DIFF
--- a/NetCord/AutoModerationActionMetadataProperties.cs
+++ b/NetCord/AutoModerationActionMetadataProperties.cs
@@ -5,12 +5,33 @@ namespace NetCord;
 [GenerateMethodsForProperties]
 public partial class AutoModerationActionMetadataProperties
 {
+    /// <summary>
+    /// The ID of the channel to which user content should be logged.
+    /// </summary>
+    /// <remarks>
+    /// Required for an <see cref="AutoModerationActionType.SendAlertMessage"/> action.
+    /// This must be an existing channel.
+    /// </remarks>
     [JsonPropertyName("channel_id")]
     public ulong? ChannelId { get; set; }
 
+    /// <summary>
+    /// The timeout duration, in seconds.
+    /// </summary>
+    /// <remarks>
+    /// Required for an <see cref="AutoModerationActionType.Timeout"/> action.
+    /// The maximum duration is 2,419,200 seconds (4 weeks).
+    /// </remarks>
     [JsonPropertyName("duration_seconds")]
     public int? DurationSeconds { get; set; }
 
+    /// <summary>
+    /// An additional explanation that will be shown to members whenever their message is blocked.
+    /// </summary>
+    /// <remarks>
+    /// Only applies to an <see cref="AutoModerationActionType.BlockMessage"/> action.
+    /// The maximum length is 150 characters.
+    /// </remarks>
     [JsonPropertyName("custom_message")]
     public string? CustomMessage { get; set; }
 }

--- a/NetCord/Channels/TextChannels/Guild/ForumGuildChannel.cs
+++ b/NetCord/Channels/TextChannels/Guild/ForumGuildChannel.cs
@@ -59,6 +59,10 @@ public partial class ForumGuildChannel : Channel, IGuildChannel
     /// <summary>
     /// The set of tags available for use in the channel.
     /// </summary>
+    /// <remarks>
+    /// Can be set when creating or updating a channel, which determines which tags can be set on individual threads within the thread’s <see cref="GuildChannelOptions.AppliedTags"/> field.
+    /// When updating a <see cref="ForumGuildChannel"/> or a <see cref="MediaForumGuildChannel"/> channel, tag objects only require the name field.
+    /// </remarks>
     public IReadOnlyList<ForumTag> AvailableTags { get; }
 
     /// <summary>

--- a/NetCord/MessagePollMediaProperties.cs
+++ b/NetCord/MessagePollMediaProperties.cs
@@ -5,9 +5,22 @@ namespace NetCord;
 [GenerateMethodsForProperties]
 public partial class MessagePollMediaProperties
 {
+    /// <summary>
+    /// The text of the poll media.
+    /// </summary>
+    /// <remarks>
+    /// This value should currently be non-null for both poll questions and poll answers.
+    /// Discord may support other forms of poll media in the future, which may not require text.
+    /// </remarks>
     [JsonPropertyName("text")]
     public string? Text { get; set; }
 
+    /// <summary>
+    /// The emoji of the poll media.
+    /// </summary>
+    /// <remarks>
+    /// This may be specified for poll answers. Poll questions currently only support <see cref="Text"/>.
+    /// </remarks> 
     [JsonPropertyName("emoji")]
     public EmojiProperties? Emoji { get; set; }
 }

--- a/NetCord/MessagePollMediaProperties.cs
+++ b/NetCord/MessagePollMediaProperties.cs
@@ -20,7 +20,7 @@ public partial class MessagePollMediaProperties
     /// </summary>
     /// <remarks>
     /// This may be specified for poll answers. Poll questions currently only support <see cref="Text"/>.
-    /// </remarks> 
+    /// </remarks>
     [JsonPropertyName("emoji")]
     public EmojiProperties? Emoji { get; set; }
 }

--- a/NetCord/Rest/ComponentProperties/ComponentMediaProperties.cs
+++ b/NetCord/Rest/ComponentProperties/ComponentMediaProperties.cs
@@ -5,6 +5,13 @@ namespace NetCord.Rest;
 [GenerateMethodsForProperties]
 public partial class ComponentMediaProperties(string url)
 {
+    /// <summary>
+    /// Source URL of the media item.
+    /// </summary>
+    /// <remarks>
+    /// Supports arbitrary urls and attachment://&lt;filename&gt; references.
+    /// For a file component, only supports using the attachment:// protocol.
+    /// </remarks>
     [JsonPropertyName("url")]
     public string Url { get; set; } = url;
 

--- a/NetCord/Rest/ComponentProperties/FileDisplayProperties.cs
+++ b/NetCord/Rest/ComponentProperties/FileDisplayProperties.cs
@@ -3,6 +3,10 @@ using System.Text.Json.Serialization;
 
 namespace NetCord.Rest;
 
+/// <summary>
+/// Represents a file component to be sent in a message.
+/// </summary>
+/// <param name="file">The file to be sent as a component. The file must be attached to the message for it to be displayed correctly, and the URL must use the attachment:// protocol.</param>
 [GenerateMethodsForProperties]
 public partial class FileDisplayProperties(ComponentMediaProperties file) : IMessageComponentProperties, IComponentContainerComponentProperties
 {
@@ -13,6 +17,13 @@ public partial class FileDisplayProperties(ComponentMediaProperties file) : IMes
     [JsonPropertyName("id")]
     public int? Id { get; set; }
 
+    /// <summary>
+    /// The file to be sent as a component.
+    /// </summary>
+    /// <remarks>
+    /// The file must be attached to the message for it to be displayed correctly.
+    /// The URL must use the attachment:// protocol.
+    /// </remarks>
     [JsonPropertyName("file")]
     public ComponentMediaProperties File { get; set; } = file;
 

--- a/NetCord/Rest/ComponentProperties/FileUploadProperties.cs
+++ b/NetCord/Rest/ComponentProperties/FileUploadProperties.cs
@@ -3,6 +3,10 @@ using System.Text.Json.Serialization;
 
 namespace NetCord.Rest;
 
+/// <summary>
+/// Represents a file upload component.
+/// </summary>
+/// <param name="customId"></param>
 [GenerateMethodsForProperties]
 public partial class FileUploadProperties(string customId) : IInteractiveComponentProperties, ILabelComponentProperties
 {

--- a/NetCord/Rest/ComponentProperties/MenuProperties.cs
+++ b/NetCord/Rest/ComponentProperties/MenuProperties.cs
@@ -32,7 +32,7 @@ public abstract partial class MenuProperties(string customId) : IInteractiveComp
     /// </summary>
     /// <remarks>
     /// In a modal, this may be 0 when <see cref="Required"/> is <see langword="false"/>.
-    /// If the menu is required, this must be at least 1.
+    /// If the menu is required, this must be at least 1 if specified.
     /// </remarks>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("min_values")]
@@ -49,7 +49,7 @@ public abstract partial class MenuProperties(string customId) : IInteractiveComp
     /// Whether the menu is disabled.
     /// </summary>
     /// <remarks>
-    /// This only applies to menus in messages. Discord does not allow a disabled menu component in a modal.
+    /// This only applies to menus in messages. Discord does not allow a disabled menu in a modal.
     /// </remarks>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     [JsonPropertyName("disabled")]

--- a/NetCord/Rest/ComponentProperties/MenuProperties.cs
+++ b/NetCord/Rest/ComponentProperties/MenuProperties.cs
@@ -30,6 +30,10 @@ public abstract partial class MenuProperties(string customId) : IInteractiveComp
     /// <summary>
     /// Minimum number of items that must be chosen, default 1 (0-25).
     /// </summary>
+    /// <remarks>
+    /// In a modal, this may be 0 when <see cref="Required"/> is <see langword="false"/>.
+    /// If the menu is required, this must be at least 1.
+    /// </remarks>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("min_values")]
     public int? MinValues { get; set; }
@@ -44,6 +48,9 @@ public abstract partial class MenuProperties(string customId) : IInteractiveComp
     /// <summary>
     /// Whether the menu is disabled.
     /// </summary>
+    /// <remarks>
+    /// This only applies to menus in messages. Discord does not allow a disabled menu component in a modal.
+    /// </remarks>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     [JsonPropertyName("disabled")]
     public bool Disabled { get; set; }
@@ -51,6 +58,10 @@ public abstract partial class MenuProperties(string customId) : IInteractiveComp
     /// <summary>
     /// Whether the menu is required to answer in a modal. Defaults to <see langword="true"/>.
     /// </summary>
+    /// <remarks>
+    /// This only applies to menus in modals and is ignored for menus in messages.
+    /// When this is <see langword="true"/> or ommited, <see cref="MinValues"/> must be at least 1 if specified.
+    /// </remarks>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("required")]
     public bool? Required { get; set; }

--- a/NetCord/Rest/ComponentProperties/MenuProperties.cs
+++ b/NetCord/Rest/ComponentProperties/MenuProperties.cs
@@ -60,7 +60,7 @@ public abstract partial class MenuProperties(string customId) : IInteractiveComp
     /// </summary>
     /// <remarks>
     /// This only applies to menus in modals and is ignored for menus in messages.
-    /// When this is <see langword="true"/> or ommited, <see cref="MinValues"/> must be at least 1 if specified.
+    /// When this is <see langword="true"/> or omitted, <see cref="MinValues"/> must be at least 1 if specified.
     /// </remarks>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("required")]

--- a/NetCord/Rest/ForumTagProperties.cs
+++ b/NetCord/Rest/ForumTagProperties.cs
@@ -8,24 +8,18 @@ public partial class ForumTagProperties(string name)
     /// <summary>
     /// The ID of the tag.
     /// </summary>
-    /// <remarks>
-    /// This is not required when updating a forum or media channel. Otherwise must be non-null.
-    /// </remarks>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("id")]
     public ulong? Id { get; set; }
 
     /// <summary>
-    /// The name of the tag.
+    /// The name of the tag. (0-20 characters)
     /// </summary>
-    /// <remarks>
-    /// The maximum length is 20 characters.
-    /// </remarks>
     [JsonPropertyName("name")]
     public string Name { get; set; } = name;
 
     /// <summary>
-    /// Whether the tag is moderated.
+    /// Whether this tag can only be added to or removed from threads by a member with the MANAGE_THREADS permission.
     /// </summary>
     /// <remarks>
     /// This is not required when updating a forum or media channel. Otherwise must be non-null.
@@ -38,7 +32,6 @@ public partial class ForumTagProperties(string name)
     /// The ID of the guild's custom emoji to display for this tag.
     /// </summary>
     /// <remarks>
-    /// This is not required when updating a forum or media channel. Otherwise must be non-null
     /// At most one of <see cref="EmojiId"/> and <see cref="EmojiName"/> may be non-null.
     /// </remarks>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -46,10 +39,9 @@ public partial class ForumTagProperties(string name)
     public ulong? EmojiId { get; set; }
 
     /// <summary>
-    /// The unicode charactor of the standard emoji to display for this tag.
+    /// The unicode character of the standard emoji to display for this tag.
     /// </summary>
     /// <remarks>
-    /// This is not required when updating a forum or media channel. Otherwise must be non-null
     /// At most one of <see cref="EmojiId"/> and <see cref="EmojiName"/> may be non-null.
     /// </remarks>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/NetCord/Rest/ForumTagProperties.cs
+++ b/NetCord/Rest/ForumTagProperties.cs
@@ -35,7 +35,7 @@ public partial class ForumTagProperties(string name)
     public bool? Moderated { get; set; }
 
     /// <summary>
-    /// The ID of the emoji to display for this tag.
+    /// The ID of the guild's custom emoji to display for this tag.
     /// </summary>
     /// <remarks>
     /// This is not required when updating a forum or media channel. Otherwise must be non-null
@@ -46,7 +46,7 @@ public partial class ForumTagProperties(string name)
     public ulong? EmojiId { get; set; }
 
     /// <summary>
-    /// The name of the emoji to display for this tag.
+    /// The unicode charactor of the standard emoji to display for this tag.
     /// </summary>
     /// <remarks>
     /// This is not required when updating a forum or media channel. Otherwise must be non-null

--- a/NetCord/Rest/ForumTagProperties.cs
+++ b/NetCord/Rest/ForumTagProperties.cs
@@ -5,21 +5,53 @@ namespace NetCord.Rest;
 [GenerateMethodsForProperties]
 public partial class ForumTagProperties(string name)
 {
+    /// <summary>
+    /// The ID of the tag.
+    /// </summary>
+    /// <remarks>
+    /// This is not required when updating a forum or media channel. Otherwise must be non-null.
+    /// </remarks>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("id")]
     public ulong? Id { get; set; }
 
+    /// <summary>
+    /// The name of the tag.
+    /// </summary>
+    /// <remarks>
+    /// The maximum length is 20 characters.
+    /// </remarks>
     [JsonPropertyName("name")]
     public string Name { get; set; } = name;
 
+    /// <summary>
+    /// Whether the tag is moderated.
+    /// </summary>
+    /// <remarks>
+    /// This is not required when updating a forum or media channel. Otherwise must be non-null.
+    /// </remarks>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("moderated")]
     public bool? Moderated { get; set; }
 
+    /// <summary>
+    /// The ID of the emoji to display for this tag.
+    /// </summary>
+    /// <remarks>
+    /// This is not required when updating a forum or media channel. Otherwise must be non-null
+    /// At most one of <see cref="EmojiId"/> and <see cref="EmojiName"/> may be non-null.
+    /// </remarks>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("emoji_id")]
     public ulong? EmojiId { get; set; }
 
+    /// <summary>
+    /// The name of the emoji to display for this tag.
+    /// </summary>
+    /// <remarks>
+    /// This is not required when updating a forum or media channel. Otherwise must be non-null
+    /// At most one of <see cref="EmojiId"/> and <see cref="EmojiName"/> may be non-null.
+    /// </remarks>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("emoji_name")]
     public string? EmojiName { get; set; }

--- a/NetCord/Rest/GuildScheduledEventProperties.cs
+++ b/NetCord/Rest/GuildScheduledEventProperties.cs
@@ -5,10 +5,23 @@ namespace NetCord.Rest;
 [GenerateMethodsForProperties]
 public partial class GuildScheduledEventProperties(string name, GuildScheduledEventPrivacyLevel privacyLevel, DateTimeOffset scheduledStartTime, GuildScheduledEventEntityType entityType)
 {
+    /// <summary>
+    /// The channel ID in which the scheduled event will be hosted, or <see langword="null"/> if the scheduled event is a <see cref="GuildScheduledEventEntityType.External"/> event.
+    /// </summary>
+    /// <remarks>
+    /// Required for a <see cref="GuildScheduledEventEntityType.StageInstance"/> or <see cref="GuildScheduledEventEntityType.Voice"/> scheduled event.
+    /// </remarks>
     [JsonPropertyName("channel_id")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public ulong? ChannelId { get; set; }
 
+    /// <summary>
+    /// Additional metadata for the scheduled event.
+    /// </summary>
+    /// <remarks>
+    /// Required for a <see cref="GuildScheduledEventEntityType.External"/> scheduled event and must contain a non-null <see cref="GuildScheduledEventMetadataProperties.Location"/> value.
+    /// Must be <see langword="null"/> for a <see cref="GuildScheduledEventEntityType.StageInstance"/> or <see cref="GuildScheduledEventEntityType.Voice"/> scheduled event.
+    /// </remarks>
     [JsonPropertyName("entity_metadata")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public GuildScheduledEventMetadataProperties? Metadata { get; set; }
@@ -22,6 +35,13 @@ public partial class GuildScheduledEventProperties(string name, GuildScheduledEv
     [JsonPropertyName("scheduled_start_time")]
     public DateTimeOffset ScheduledStartTime { get; set; } = scheduledStartTime;
 
+    /// <summary>
+    /// The time when the scheduled event is scheduled to end.
+    /// </summary>
+    /// <remarks>
+    /// Required for a <see cref="GuildScheduledEventEntityType.External"/> scheduled event.
+    /// Must be <see langword="null"/> for a <see cref="GuildScheduledEventEntityType.StageInstance"/> or <see cref="GuildScheduledEventEntityType.Voice"/> scheduled event.
+    /// </remarks>
     [JsonPropertyName("scheduled_end_time")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public DateTimeOffset? ScheduledEndTime { get; set; }
@@ -30,6 +50,12 @@ public partial class GuildScheduledEventProperties(string name, GuildScheduledEv
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Description { get; set; }
 
+    /// <summary>
+    /// The type of the scheduled event.
+    /// </summary>
+    /// <remarks>
+    /// This determines the requirements for the <see cref="ChannelId"/>, <see cref="Metadata"/>, and <see cref="ScheduledEndTime"/> properties.
+    /// </remarks>
     [JsonPropertyName("entity_type")]
     public GuildScheduledEventEntityType EntityType { get; set; } = entityType;
 

--- a/NetCord/Rest/GuildScheduledEventProperties.cs
+++ b/NetCord/Rest/GuildScheduledEventProperties.cs
@@ -26,12 +26,21 @@ public partial class GuildScheduledEventProperties(string name, GuildScheduledEv
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public GuildScheduledEventMetadataProperties? Metadata { get; set; }
 
+    /// <summary>
+    /// The name of the scheduled event. (1-100 characters)
+    /// </summary>
     [JsonPropertyName("name")]
     public string Name { get; set; } = name;
 
+    /// <summary>
+    /// The privacy level of the scheduled event.
+    /// </summary>
     [JsonPropertyName("privacy_level")]
     public GuildScheduledEventPrivacyLevel PrivacyLevel { get; set; } = privacyLevel;
 
+    /// <summary>
+    /// The time when the scheduled event will start.
+    /// </summary>
     [JsonPropertyName("scheduled_start_time")]
     public DateTimeOffset ScheduledStartTime { get; set; } = scheduledStartTime;
 
@@ -40,12 +49,15 @@ public partial class GuildScheduledEventProperties(string name, GuildScheduledEv
     /// </summary>
     /// <remarks>
     /// Required for a <see cref="GuildScheduledEventEntityType.External"/> scheduled event.
-    /// Must be <see langword="null"/> for a <see cref="GuildScheduledEventEntityType.StageInstance"/> or <see cref="GuildScheduledEventEntityType.Voice"/> scheduled event.
+    /// This field has no strict requirements for a <see cref="GuildScheduledEventEntityType.StageInstance"/> or <see cref="GuildScheduledEventEntityType.Voice"/> scheduled event.
     /// </remarks>
     [JsonPropertyName("scheduled_end_time")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public DateTimeOffset? ScheduledEndTime { get; set; }
 
+    /// <summary>
+    /// The description of the scheduled event. (1-1000 characters)
+    /// </summary>
     [JsonPropertyName("description")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Description { get; set; }
@@ -59,6 +71,9 @@ public partial class GuildScheduledEventProperties(string name, GuildScheduledEv
     [JsonPropertyName("entity_type")]
     public GuildScheduledEventEntityType EntityType { get; set; } = entityType;
 
+    /// <summary>
+    /// The cover image of the scheduled event.
+    /// </summary>
     [JsonPropertyName("image")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public ImageProperties? Image { get; set; }


### PR DESCRIPTION
This pull request adds detailed XML documentation comments to some property classes in the codebase, clarifying property usage, requirements and constraints for Discord API models. 